### PR TITLE
ci: ajoute windows-latest à la matrice pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,10 +14,16 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    defaults:
+      run:
+        # Force bash (dispo via Git Bash sur windows-latest) pour un comportement
+        # identique sur les trois OS (notamment `pip install -e .[test]` et la
+        # sélection conditionnelle de `--full`).
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.12']
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,10 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # La suite complète (`--full`, lancement manuel) télécharge tous les paquets
+    # de chaque modèle sur les deux jeux de définitions GRIB : elle dépasse
+    # largement 30 min. La suite partielle des PR reste bornée à 30 min.
+    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' && inputs.full) && 120 || 30 }}
     defaults:
       run:
         # Force bash (dispo via Git Bash sur windows-latest) pour un comportement


### PR DESCRIPTION
## Objectif

Ajouter `windows-latest` à la matrice de la CI pytest, en plus de `ubuntu-latest` et `macos-latest`, et vérifier le comportement sous Windows (notamment la limite des 2 Go de `cfgrib`).

## Changements

- **Matrice** : `os: [ubuntu-latest, macos-latest, windows-latest]`.
- **`shell: bash`** forcé au niveau du job. Sur `windows-latest` le shell par défaut est PowerShell, qui interprète différemment les crochets de `pip install -e .[test]` et n'a pas l'opérateur `&& … || ''` servant à sélectionner `--full`. Git Bash étant préinstallé sur les runners Windows, forcer bash garantit un comportement identique sur les trois OS.
- **Timeout conditionnel** : `120 min` pour le run manuel `--full`, `30 min` pour la suite partielle des PR. La suite complète télécharge tous les paquets réels de chaque modèle sur les deux jeux de définitions GRIB et dépasse largement 30 min (elle était déjà coupée à 30 min avant cette PR, sur les trois OS).

## Résultats CI

### Suite restreinte (défaut PR) — ✅ verte sur les 3 OS
`ubuntu-latest`, `macos-latest`, `windows-latest` : tous verts (~10 min). Le pipeline standard `cfgrib.open_datasets` fonctionne sous Windows.

### Suite complète (`--full`, workflow_dispatch) — tests OK, runs interrompus
Chaque test exécuté est **PASSED** sur les trois OS (aucun échec observé, sur l'ensemble des tests de disponibilité + plusieurs modèles complets). Les runs `--full` n'ont toutefois **pas pu aller au bout** : ils sont interrompus prématurément (à 26 min puis 3,5 min, bien avant le timeout de 120 min), par une annulation côté compte. À investiguer séparément (durée/coût des runs full sur 3 OS, ~75-90 min attendus).

## Sur la limite des 2 Go GRIB sous Windows

`cfgrib` ne sait pas lire un fichier GRIB > 2 Go sous Windows. `Model._read_grib` (`meteofetch/_model.py`) gère déjà ce cas en découpant le fichier par variable via `grib_copy` lorsque `system() == "Windows"` et `getsize(path) >= 2**31`.

Deux constats :

1. **Les tests ne déclenchent pas cette branche.** La suite limite chaque modèle à 2 échéances (`N_GROUPS = 2` / `groups_[:2]`), donc aucun fichier téléchargé n'atteint 2 Go, y compris en mode `--full`. La CI Windows valide donc le pipeline standard, pas le découpage.
2. **`grib_copy` n'est pas fourni par le wheel `eccodes` pip** (seule la bibliothèque partagée l'est, pas les outils CLI). Le workaround > 2 Go dépend donc d'un `grib_copy` présent sur le `PATH`, ce qui n'est pas garanti dans un environnement pip pur sous Windows. Non régressé par cette PR (branche non exécutée en test), mais à garder en tête pour les utilisateurs Windows manipulant de gros paquets réels — à traiter séparément si besoin.

## Validation

- [x] Suite restreinte (défaut PR) verte sur les 3 OS.
- [ ] Suite complète (`--full`) : tous les tests passent, mais les runs sont interrompus côté compte avant complétion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)