### PR TITLE
Fix Windows GRIB splitting without grib_copy

### DIFF
--- a/meteofetch/_model.py
+++ b/meteofetch/_model.py
@@ -1,16 +1,15 @@
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
-from glob import glob
+from contextlib import ExitStack
 from multiprocessing import Pool
 from os.path import basename, getsize
 from pathlib import Path
 from platform import system
+from re import sub
 from shutil import copyfileobj
-from subprocess import CalledProcessError, run
 from typing import Dict, List, Union
 
-import cfgrib
 import pandas as pd
 import requests
 import xarray as xr
@@ -18,6 +17,12 @@ import xarray as xr
 from ._misc import geo_encode_cf
 
 logger = logging.getLogger(__name__)
+
+
+def _import_cfgrib():
+    import cfgrib
+
+    return cfgrib
 
 
 class Model:
@@ -94,27 +99,54 @@ class Model:
         """Open a GRIB2 file and return a list of datasets (one per variable group).
 
         On Windows, cfgrib cannot handle files larger than 2 GB. In that case the
-        file is first split into per-variable files using ``grib_copy``, then each
-        split file is opened individually.
+        file is first split into per-variable files with the ecCodes Python API,
+        then each split file is opened individually.
         """
+        cfgrib = _import_cfgrib()
         kw = dict(backend_kwargs={"decode_timedelta": True, "indexpath": ""}, cache=False)
         if system() == "Windows" and getsize(path) >= 2**31:
             file_name = basename(path).split(".")[0]
-            path_split = Path(path).parent / f"split_{file_name}_[shortName].grib2"
-            command = f"grib_copy {path} {path_split.resolve()}"
-            try:
-                run(command, check=True)
-                Path(path).unlink()
-                paths = glob(str(Path(path).parent / f"split_{file_name}_*.grib2"))
-                datasets = []
-                for path_variable in paths:
-                    datasets.append(cfgrib.open_dataset(path=path_variable, **kw))
-                return datasets
-            except CalledProcessError:
-                raise
+            paths = cls._split_grib_by_short_name(path, file_name)
+            Path(path).unlink()
+            datasets = []
+            for path_variable in paths:
+                datasets.append(cfgrib.open_dataset(path=path_variable, **kw))
+            return datasets
         else:
             # Cas le plus courant
             return cfgrib.open_datasets(path=path, **kw)
+
+    @staticmethod
+    def _split_grib_by_short_name(path, file_name: str) -> List[Path]:
+        """Split a GRIB file into one file per ecCodes ``shortName``."""
+        import eccodes
+
+        split_dir = Path(path).parent
+        paths_by_short_name: Dict[str, Path] = {}
+
+        with open(path, "rb") as source, ExitStack() as stack:
+            files = {}
+            while True:
+                message = eccodes.codes_grib_new_from_file(source)
+                if message is None:
+                    break
+
+                try:
+                    short_name = str(eccodes.codes_get(message, "shortName"))
+                    safe_short_name = sub(r"[^A-Za-z0-9_.-]+", "_", short_name).strip("._")
+                    if not safe_short_name:
+                        safe_short_name = "unknown"
+
+                    if safe_short_name not in files:
+                        split_path = split_dir / f"split_{file_name}_{safe_short_name}.grib2"
+                        paths_by_short_name[safe_short_name] = split_path
+                        files[safe_short_name] = stack.enter_context(open(split_path, "wb"))
+
+                    eccodes.codes_write(message, files[safe_short_name])
+                finally:
+                    eccodes.codes_release(message)
+
+        return list(paths_by_short_name.values())
 
     @classmethod
     def _read_multiple_gribs(cls, paths, variables, num_workers) -> Dict[str, xr.DataArray]:

--- a/tests/test_model_grib_split.py
+++ b/tests/test_model_grib_split.py
@@ -1,0 +1,73 @@
+import sys
+from types import SimpleNamespace
+
+from meteofetch import _model
+from meteofetch._model import Model
+
+
+class FakeEccodes:
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.released = []
+
+    def codes_grib_new_from_file(self, source):
+        return self.messages.pop(0) if self.messages else None
+
+    def codes_get(self, message, key):
+        assert key == "shortName"
+        return message.short_name
+
+    def codes_write(self, message, target):
+        target.write(message.payload)
+
+    def codes_release(self, message):
+        self.released.append(message)
+
+
+def test_split_grib_by_short_name_groups_messages(monkeypatch, tmp_path):
+    messages = [
+        SimpleNamespace(short_name="2t", payload=b"temperature-0"),
+        SimpleNamespace(short_name="10u", payload=b"wind"),
+        SimpleNamespace(short_name="2t", payload=b"temperature-1"),
+    ]
+    fake_eccodes = FakeEccodes(messages)
+    monkeypatch.setitem(sys.modules, "eccodes", fake_eccodes)
+
+    path = tmp_path / "forecast.grib2"
+    path.write_bytes(b"source")
+
+    split_paths = Model._split_grib_by_short_name(path, "forecast")
+
+    assert split_paths == [
+        tmp_path / "split_forecast_2t.grib2",
+        tmp_path / "split_forecast_10u.grib2",
+    ]
+    assert split_paths[0].read_bytes() == b"temperature-0temperature-1"
+    assert split_paths[1].read_bytes() == b"wind"
+    assert fake_eccodes.released == messages
+
+
+def test_large_windows_grib_uses_python_splitter(monkeypatch, tmp_path):
+    original_path = tmp_path / "forecast.grib2"
+    original_path.write_bytes(b"source")
+    split_paths = [tmp_path / "split_forecast_2t.grib2", tmp_path / "split_forecast_10u.grib2"]
+    for split_path in split_paths:
+        split_path.write_bytes(b"split")
+
+    monkeypatch.setattr(_model, "system", lambda: "Windows")
+    monkeypatch.setattr(_model, "getsize", lambda path: 2**31)
+    monkeypatch.setattr(Model, "_split_grib_by_short_name", staticmethod(lambda path, file_name: split_paths))
+
+    opened_paths = []
+
+    def fake_open_dataset(path, **kwargs):
+        opened_paths.append(path)
+        return path.name
+
+    monkeypatch.setattr(_model, "_import_cfgrib", lambda: SimpleNamespace(open_dataset=fake_open_dataset))
+
+    datasets = Model._read_grib(original_path)
+
+    assert datasets == ["split_forecast_2t.grib2", "split_forecast_10u.grib2"]
+    assert opened_paths == split_paths
+    assert not original_path.exists()


### PR DESCRIPTION
## Summary
- Fix Windows handling of GRIB files larger than 2 GiB without relying on the external grib_copy executable.
- Split large GRIB files through the Python ecCodes API before opening per-variable datasets with cfgrib.

## Main changes
- Add a shortName-based splitter in meteofetch/_model.py using codes_grib_new_from_file, codes_get, codes_write, and codes_release.
- Keep cfgrib import lazy so unit tests can mock the reader without requiring the native ecCodes library at import time.
- Add focused tests for message grouping and the Windows large-file read path.

## Validation
- rtk uv run --extra test pytest -q tests/test_model_grib_split.py
- rtk python3 -m compileall meteofetch tests
- rtk proxy git diff --check