### PR TITLE
ci: gère les PR de fork dans le formatage Ruff

### DIFF
--- a/.github/workflows/ruff-format-pr.yml
+++ b/.github/workflows/ruff-format-pr.yml
@@ -10,26 +10,31 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.head_ref }}
-          # Pousser le commit de reformatage avec un PAT (secret CI_PAT) plutôt
-          # qu'avec le GITHUB_TOKEN : un push authentifié par le GITHUB_TOKEN ne
-          # re-déclenche AUCUN workflow, ce qui laisserait les checks `test`
-          # absents du commit final et bloquerait le merge. Avec un PAT, le push
-          # relance la CI. Repli sur github.token si le secret n'est pas défini
-          # (ex. PR issue d'un fork, qui n'a pas accès aux secrets).
-          token: ${{ secrets.CI_PAT || github.token }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ github.event.pull_request.head.repo.full_name == github.repository && (secrets.CI_PAT || github.token) || github.token }}
 
       - name: Install Ruff
         run: pip install ruff
 
       - name: Run ruff format
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: ruff format .
 
+      - name: Check ruff format
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: ruff format --check .
+
       - name: Run ruff check (imports)
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: ruff check --select I --fix .
 
+      - name: Check ruff imports
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: ruff check --select I .
+
       - name: Commit changes
-        if: success()
+        if: success() && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git diff --quiet || (git add . && \
           git -c user.name="GitHub Actions" \


### PR DESCRIPTION
## Summary
- Checkout le dépôt source de la PR au lieu de supposer que la branche existe dans le dépôt principal.
- Garde l'auto-format + push pour les PR internes.
- Passe les PR de fork en vérification seule, car le token est en lecture seule et les secrets ne sont pas disponibles.

## Validation
- rtk proxy ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ruff-format-pr.yml"); puts "yaml ok"'
- rtk proxy git diff --check